### PR TITLE
Remove HTML encoding of path

### DIFF
--- a/dremio_client/model/endpoints.py
+++ b/dremio_client/model/endpoints.py
@@ -94,8 +94,7 @@ def catalog_item(token, base_url, cid=None, path=None, ssl_verify=True):
     if cid is None and path is None:
         raise TypeError("both id and path can't be None for a catalog_item call")
     idpath = (cid if cid else "") + ", " + (".".join(path) if path else "")
-    cpath = [i.replace("/", "%2F") for i in path] if path else ""
-    endpoint = "/{}".format(cid) if cid else "/by-path/{}".format("/".join(cpath).replace('"', ""))
+    endpoint = "/{}".format(cid) if cid else "/by-path/{}".format("/".join(path).replace('"', ""))
     return _get(base_url + "/api/v3/catalog{}".format(endpoint), token, idpath, ssl_verify=ssl_verify)
 
 


### PR DESCRIPTION
Where querying dremio using HTTPS, current code works fine.

However when querying:
- dremio using HTTP
- with the dremio_client utility
- with a path and not a cid

Then, I get this error : 

```
# dremio_client catalog-item BDF.example_bug_round
Traceback (most recent call last):
  File "/usr/local/bin/dremio_client", line 8, in <module>
    sys.exit(cli())
  File "/usr/local/lib/python3.8/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.8/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.8/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.8/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/click/decorators.py", line 33, in new_func
    return f(get_current_context().obj, *args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/dremio_client/cli.py", line 181, in catalog_item
    x = _catalog_item(token, base_url, cid, [i.replace(".", "/") for i in path] if path else None, ssl_verify=verify,)
  File "/usr/local/lib/python3.8/site-packages/dremio_client/model/endpoints.py", line 99, in catalog_item
    return _get(base_url + "/api/v3/catalog{}".format(endpoint), token, idpath, ssl_verify=ssl_verify)
  File "/usr/local/lib/python3.8/site-packages/dremio_client/model/endpoints.py", line 44, in _get
    return _check_error(r, details)
  File "/usr/local/lib/python3.8/site-packages/dremio_client/model/endpoints.py", line 77, in _check_error
    raise DremioNotFoundException("No entity exists at " + details, error)
dremio_client.error.DremioNotFoundException: No entity exists at , BDF/example_bug_round: 404 Client Error: Not Found for url: http://xxxx:81/api/v3/catalog/by-path/BDF%2Fexample_bug_round
```

If I remove the HTML conversion then it solves the problem, and it still works with HTTPS...
I don't know why this conversion was here in the first place.